### PR TITLE
fix: app crashes at launch with R8 full mode minification

### DIFF
--- a/core/proguard-rules.pro
+++ b/core/proguard-rules.pro
@@ -63,6 +63,8 @@
 #Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
 -keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
 -keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class com.google.common.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.common.reflect.TypeToken
 
 #Retain classes for sqlcipher.
 -keep,includedescriptorclasses class net.sqlcipher.** { *; }


### PR DESCRIPTION
This package uses both `com.google.common.reflect` and `com.google.gson.reflect` for `TypeToken` but only has proguard rules to avoid R8 full mode code shrinking for the `gson` package.

Hence, flutter apps with `minifyEnabled` and `shrinkResources` set to true were crashing at launch with the error:

```console
E/flutter ( 6248): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: PlatformException(SHARED_PREFERENCES_NOT_AVAILABLE, class com.google.common.reflect.TypeToken isn't parameterized, sharedPreferences.get, null)
```