### PR TITLE
Fix: resolve mainTargetClassName correctly to handle activity aliases

### DIFF
--- a/core/src/main/java/me/carda/awesome_notifications/core/builders/NotificationBuilder.java
+++ b/core/src/main/java/me/carda/awesome_notifications/core/builders/NotificationBuilder.java
@@ -9,6 +9,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
@@ -404,9 +405,14 @@ public class NotificationBuilder {
                         .getPackageManager()
                         .queryIntentActivities(intent, 0);
 
-        if(resolveInfoList.size() > 0)
-            mainTargetClassName = resolveInfoList.get(0).activityInfo.name;
-
+        if(resolveInfoList.size() > 0){
+               ActivityInfo activityInfo = resolveInfoList.get(0).activityInfo;
+            if (activityInfo.targetActivity != null) {
+                mainTargetClassName = activityInfo.targetActivity;
+            } else {
+                mainTargetClassName = activityInfo.name;
+            }
+        }
         return this;
     }
 


### PR DESCRIPTION
### Problem
When creating notifications in apps that use <activity-alias>, the NotificationBuilder
was setting `mainTargetClassName` using only `activityInfo.name`. This caused a crash:

    Attempt to invoke virtual method 'java.lang.String java.lang.Class.getName()'
    on a null object reference

because the launcher alias did not have a direct activity class associated with it.

### Solution
Updated `updateMainTargetClassName()` to:
1. Check `activityInfo.targetActivity` first.
2. Fall back to `activityInfo.name` if `targetActivity` is null.

This ensures that `mainTargetClassName` always points to a valid activity class,
even when the launcher entry is an alias.

### Testing
- Verified with normal launcher activity (no alias).
- Verified with launcher alias.
- Notifications now open the correct main activity in all cases without crashing.
