### PR TITLE
fix(android): honor criticalAlert on notification content

### DIFF
--- a/core/src/main/java/me/carda/awesome_notifications/core/Definitions.java
+++ b/core/src/main/java/me/carda/awesome_notifications/core/Definitions.java
@@ -233,6 +233,7 @@ public interface Definitions {
     String NOTIFICATION_ICON = "icon";
     String NOTIFICATION_FULL_SCREEN_INTENT = "fullScreenIntent";
     String NOTIFICATION_WAKE_UP_SCREEN = "wakeUpScreen";
+    String NOTIFICATION_CRITICAL_ALERT = "criticalAlert";
     String NOTIFICATION_PLAY_SOUND = "playSound";
     String NOTIFICATION_SOUND_SOURCE = "soundSource";
     String NOTIFICATION_ENABLE_VIBRATION = "enableVibration";
@@ -313,6 +314,7 @@ public interface Definitions {
         put(Definitions.NOTIFICATION_SHOW_IN_COMPACT_VIEW, true);
         put(Definitions.NOTIFICATION_IS_DANGEROUS_OPTION, false);
         put(Definitions.NOTIFICATION_WAKE_UP_SCREEN, false);
+        put(Definitions.NOTIFICATION_CRITICAL_ALERT, false);
         put(Definitions.NOTIFICATION_CHANNEL_CRITICAL_ALERTS, false);
         put(Definitions.NOTIFICATION_ROUNDED_LARGE_ICON, false);
         put(Definitions.NOTIFICATION_ROUNDED_BIG_PICTURE, false);

--- a/core/src/main/java/me/carda/awesome_notifications/core/builders/NotificationBuilder.java
+++ b/core/src/main/java/me/carda/awesome_notifications/core/builders/NotificationBuilder.java
@@ -203,7 +203,7 @@ public class NotificationBuilder {
         updateTrackingExtras(notificationModel, channelModel, androidNotification.extras);
 
         setWakeUpScreen(context, notificationModel);
-        setCriticalAlert(context, channelModel);
+        setCriticalAlert(context, channelModel, notificationModel);
         setCategoryFlags(context, notificationModel, androidNotification);
 
         setBadge(context, notificationModel, channelModel, builder);
@@ -700,8 +700,10 @@ public class NotificationBuilder {
                 wakeUpScreen(context);
     }
 
-    private void setCriticalAlert(Context context, NotificationChannelModel channel) throws AwesomeNotificationsException {
-        if (channel.criticalAlerts)
+    private void setCriticalAlert(Context context, NotificationChannelModel channel, NotificationModel notificationModel) throws AwesomeNotificationsException {
+        boolean requested = BooleanUtils.getInstance().getValue(channel.criticalAlerts, false)
+                || BooleanUtils.getInstance().getValue(notificationModel.content.criticalAlert, false);
+        if (requested)
             ensureCriticalAlert(context);
     }
 

--- a/core/src/main/java/me/carda/awesome_notifications/core/models/NotificationContentModel.java
+++ b/core/src/main/java/me/carda/awesome_notifications/core/models/NotificationContentModel.java
@@ -69,6 +69,8 @@ public class NotificationContentModel extends AbstractModel {
 
     public Boolean wakeUpScreen;
 
+    public Boolean criticalAlert;
+
     public Boolean fullScreenIntent;
 
     public Boolean hideLargeIconOnExpand;
@@ -176,6 +178,7 @@ public class NotificationContentModel extends AbstractModel {
         playSound             = getValueOrDefault(arguments, Definitions.NOTIFICATION_PLAY_SOUND, Boolean.class, true);
         customSound           = getValueOrDefault(arguments, Definitions.NOTIFICATION_CUSTOM_SOUND, String.class, null);
         wakeUpScreen          = getValueOrDefault(arguments, Definitions.NOTIFICATION_WAKE_UP_SCREEN, Boolean.class, false);
+        criticalAlert         = getValueOrDefault(arguments, Definitions.NOTIFICATION_CRITICAL_ALERT, Boolean.class, false);
         fullScreenIntent      = getValueOrDefault(arguments, Definitions.NOTIFICATION_FULL_SCREEN_INTENT, Boolean.class, false);
         showWhen              = getValueOrDefault(arguments, Definitions.NOTIFICATION_SHOW_WHEN, Boolean.class, true);
         locked                = getValueOrDefault(arguments, Definitions.NOTIFICATION_LOCKED, Boolean.class, false);
@@ -240,6 +243,7 @@ public class NotificationContentModel extends AbstractModel {
         putDataOnSerializedMap(Definitions.NOTIFICATION_SUMMARY, returnedObject, this.summary);
         putDataOnSerializedMap(Definitions.NOTIFICATION_SHOW_WHEN, returnedObject, this.showWhen);
         putDataOnSerializedMap(Definitions.NOTIFICATION_WAKE_UP_SCREEN, returnedObject, this.wakeUpScreen);
+        putDataOnSerializedMap(Definitions.NOTIFICATION_CRITICAL_ALERT, returnedObject, this.criticalAlert);
         putDataOnSerializedMap(Definitions.NOTIFICATION_FULL_SCREEN_INTENT, returnedObject, this.fullScreenIntent);
         putDataOnSerializedMap(Definitions.NOTIFICATION_ACTION_TYPE, returnedObject, this.actionType);
         putDataOnSerializedMap(Definitions.NOTIFICATION_LOCKED, returnedObject, this.locked);

--- a/core/src/test/java/me/carda/awesome_notifications/core/models/NotificationContentModelTest.java
+++ b/core/src/test/java/me/carda/awesome_notifications/core/models/NotificationContentModelTest.java
@@ -1,0 +1,47 @@
+package me.carda.awesome_notifications.core.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import me.carda.awesome_notifications.core.Definitions;
+
+public class NotificationContentModelTest {
+
+    @Test
+    public void fromMap_readsCriticalAlertFlag() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put(Definitions.NOTIFICATION_CHANNEL_KEY, "test_channel");
+        map.put(Definitions.NOTIFICATION_CRITICAL_ALERT, true);
+
+        NotificationContentModel content = new NotificationContentModel().fromMap(map);
+
+        assertTrue(content.criticalAlert);
+    }
+
+    @Test
+    public void fromMap_defaultsCriticalAlertToFalse() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put(Definitions.NOTIFICATION_CHANNEL_KEY, "test_channel");
+
+        NotificationContentModel content = new NotificationContentModel().fromMap(map);
+
+        assertFalse(content.criticalAlert);
+    }
+
+    @Test
+    public void toMap_serializesCriticalAlertFlag() throws Exception {
+        NotificationContentModel content = new NotificationContentModel();
+        content.channelKey = "test_channel";
+        content.criticalAlert = true;
+
+        Map<String, Object> map = content.toMap();
+
+        assertEquals(true, map.get(Definitions.NOTIFICATION_CRITICAL_ALERT));
+    }
+}


### PR DESCRIPTION
## Summary

Android ignored the per-notification `criticalAlert` flag; only the channel flag triggered critical behavior.

## What changed

**Definitions**
- Added `NOTIFICATION_CRITICAL_ALERT` constant

**NotificationContentModel**
- Added `criticalAlert` field with fromMap/toMap support

**NotificationBuilder**
- `setCriticalAlert()` now triggers when channel **or** content requests it

**Tests**
- Unit tests for fromMap, default false, and toMap serialization

## Why

Dart exposes `criticalAlert` on content; Android must honor it for parity with iOS and for FCM payloads that set the flag per notification.

## Test plan

- [ ] Unit tests pass
- [ ] Notification with `criticalAlert: true` on a standard channel